### PR TITLE
Fix t value for numpy error

### DIFF
--- a/Question_prepare/answer_data_load.py
+++ b/Question_prepare/answer_data_load.py
@@ -12,7 +12,7 @@ def data_load(path):
     xs = np.ndarray((0, img_height, img_width, 3))
     ts = np.ndarray((0))
     paths = []
-    
+
     for dir_path in glob(path + '/*'):
         for path in glob(dir_path + '/*'):
             x = cv2.imread(path)
@@ -20,11 +20,11 @@ def data_load(path):
             x /= 255.
             xs = np.r_[xs, x[None, ...]]
 
-            t = np.zeros((1))
+            t = None
             if 'akahara' in path:
-                t = np.array((0))
+                t = 0
             elif 'madara' in path:
-                t = np.array((1))
+                t = 1
             ts = np.r_[ts, t]
 
             paths.append(path)


### PR DESCRIPTION
以下のようなエラーが出たので修正しました。
```
Traceback (most recent call last):
  File "answer_data_load.py", line 36, in <module>
    xs, ts, paths = data_load("../Dataset/train/images/")
  File "answer_data_load.py", line 28, in data_load
    ts = np.r_[ts, t]
  File "/Users/karaage/.pyenv/versions/anaconda3-4.4.0/envs/ml/lib/python3.6/site-packages/numpy/lib/index_tricks.py", line 340, in __getitem__
    res = self.concatenate(tuple(objs), axis=axis)
ValueError: all the input arrays must have same number of dimensions
```

バージョンは以下です。
Python 3.6.1
numpy 1.14.5

　numpyはあまり詳しくないです。numpyのバージョンの違いも把握できていないです。
`np.r_` に関しても理解が浅いです。`np.vstack`と同じなのかと思っていたのですが、挙動違いました。
 np.vstack((ts, t)) を使う場合だと、以下のように修正することで対応できました。

```
 # get train data
 def data_load(path):
     xs = np.ndarray((0, img_height, img_width, 3))
-    ts = np.ndarray((0))
+    ts = np.ndarray((None))
     paths = []
     
     for dir_path in glob(path + '/*'):
@@ -23,9 +23,9 @@ def data_load(path):
             t = np.zeros((1))
             if 'akahara' in path:
                 t = np.array((0))
-            elif 'madara' in path:
+            if 'madara' in path:
                 t = np.array((1))
-            ts = np.r_[ts, t]
+            ts = np.vstack((ts, t))
 
             paths.append(path)
```

　気になったのでPRお送りいたしました。私の理解不足で変なPR送っていたらすみません。