### PR TITLE
ミニバッチの処理の修正

### DIFF
--- a/Question_prepare/answers/answer_minibatch.py
+++ b/Question_prepare/answers/answer_minibatch.py
@@ -1,6 +1,7 @@
 import cv2
 import numpy as np
 from glob import glob
+import copy
 
 np.random.seed(0)
 
@@ -48,7 +49,7 @@ np.random.shuffle(train_ind)
 
 for i in range(10):
     if mbi + mb > len(xs):
-        mb_ind = train_ind[mbi:]
+        mb_ind = copy.copy(train_ind)[mbi:]
         np.random.shuffle(train_ind)
         mb_ind = np.hstack((mb_ind, train_ind[:(mb-(len(xs)-mbi))]))
         mbi = mb - (len(xs) - mbi)


### PR DESCRIPTION
こんにちは
勉強にとても活用させていただいています。

Question_prepare/answer_minibatch.py の記述と結果が少し想定していたものと異なっていたため、PRを送らせていただきます。

Pythonのlistのコピーはshallow copyのため
```
mb_ind = train_ind[mbi:]
np.random.shuffle(train_ind)
```
このように記述すると、mb_indにはtrain_indをshuffleしたあとの一番最後の要素が入ってしまうため、以下のようにdeep copyして要素を取り出すように修正しました。
```
mb_ind = copy.copy(train_ind)[mbi:]
np.random.shuffle(train_ind)
```